### PR TITLE
exheredrey-0: init

### DIFF
--- a/paludis/repositories/e/ebuild/exheredrey-0/CONTRIBUTING.md
+++ b/paludis/repositories/e/ebuild/exheredrey-0/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+Contributing to this library is regulated by:
+https://github.com/Kreyrock/Kreyrock/blob/master/CONTRIBUTING.md

--- a/paludis/repositories/e/ebuild/exheredrey-0/LICENSE.md
+++ b/paludis/repositories/e/ebuild/exheredrey-0/LICENSE.md
@@ -1,0 +1,2 @@
+License of this repository is regulated by file present on this hyperlink:
+https://github.com/Kreyren/LICENCES/blob/master/JKHL.md

--- a/paludis/repositories/e/ebuild/exheredrey-0/README.md
+++ b/paludis/repositories/e/ebuild/exheredrey-0/README.md
@@ -1,0 +1,19 @@
+# Exheredrey
+
+This is an ebuild-inspired library designed to be used for (paludis)[https://paludis.exherbo.org/] and (portage)[https://en.wikipedia.org/wiki/Portage_(software)] package managers backends used in Exherbo Linux and Gentoo Linux or anything that can run shell/bash scripts
+
+Inspired by Exherbo Linux this is expected to source the logic using libraries (exlibs) instead of writing logic per file like it is a tradition to Gentoo which is obviously more efficient to handle downstream
+
+### Standards
+
+#### Pass shellcheck
+Current `exheres-0` (20122019) has multiple minor to major issues that doesn't pass shellcheck which is not acceptable in exheredrey.
+
+#### Write docummentation
+Neither of Gentoo nor Exherbo's docummentation is usefull for contributors which is not acceptable in exheredrey.
+
+#### Oversanitization
+TODO link Kreyrock contributing
+
+#### Translate
+TODO Everything is expected to be translated and linked to translate for crowd sourcing

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/default.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/default.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'fixme' from Exherbo Linux which is:
+# 	General Public License v2
+
+: '
+Wrapper to execute default logic in a phase on demand for example:
+
+	src_test() {
+		[ ! -e file ] && rm file
+
+		default
+	}
+
+Which is going to remove a file prior to executing default logic for tests (logic is specifies in said phase)
+'
+
+efixme NotTested default
+
+case $1 in
+	configure|compile|install) "default_src_$1" ;;
+	*) die 2 "Unsupported argument has been parsed - $1"
+esac

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/die.bash
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/die.bash
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+	# We are using FUNCNAME which blocks POSIX compatibility
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+# Uses bash for FUNCNAME otherwise optimized for shell
+
+: '
+Output error message and exits depending on the input
+
+Usage: die EXITCODE MESSAGE
+
+Exit codes are based on available informations
+- http://tldp.org/LDP/abs/html/exitcodes.html#EXITCODESREF
+
+Exit codes (EXITCODE):
+	0       True (will not exit)
+	1       False
+	2       Syntax error
+	3       Permission error
+	126     Not executable
+	130     Killed by end-user
+	255     Unexpected result
+
+Exit code 255 is used to handle if statement logic for runtime quality assurance alike:
+
+if [ -e file ]; then
+	action
+elif [ ! -h file ]; then
+	action
+else
+	die 255 "Checking for file"
+fi
+
+Notice that in this case no all posibilities are covered so if file is a symlink the else is supposed to trigger informing the developer to adapt logic
+
+Message (MESSAGE) is expected to be as one argument, multiple arguments will result in an error by design'
+die() {
+	err_code="$1"
+	message="$2"
+	syntax_err="$3"
+
+	# Output error if more then expected arguments is parsed
+	[ -n "$syntax_err" ] && printf 'ERROR: %s\n' "Unexpected argument has been parsed in die"
+
+	# Used to customize the output can be set in $pckmdir/bashrc i.e: /etc/paludis/bashrc
+	[ -z "$en_die_output" ] && en_die_output="FATAL(${FUNCNAME[1]}):"
+	[ -z "$cz_die_output" ] && cz_die_output="FATALNÍ(${FUNCNAME[1]}):"
+	[ -z "$sk_die_output" ] && sk_die_output="ČOBOLO(${FUNCNAME[1]}):"
+	#                                         ^^^^^^ - Now we wait for angry čobolaks
+	[ -z "$general_die_output" ] && general_die_output="FATAL(${FUNCNAME[1]}):"
+
+	# HELPER: Handle die output to avoid duplicate
+	die_output() {
+		if [ -n "$message" ]; then
+			case $LANG in
+				en*) printf "$en_die_output %s\\n" "$message" 1>&2 ;;
+				cz*) printf "$cz_die_output %s\\n" "$message" 1>&2 ;;
+				sk*) printf "$cz_die_output %s\\n" "$message" 1>&2 ;;
+				*) printf "$general_die_output %s\\n" "$message" 1>&2
+			esac
+		elif [ -z "$message" ]; then
+			die_message
+		else
+			printf 'FATAL: Unexpected happend in die error code - %s\n' "$err_code"
+		fi
+
+		exit "$err_code"
+	}
+
+	case "$err_code" in
+		0|true) true ;;
+		1|false) # False
+			die_message() {
+				case $LANG in
+					en*) printf "$general_die_output %s\\n" "Function $MYFUNCNAME returned false" ;;
+					*) printf "$general_die_output %s\\n" "Function $MYFUNCNAME returned false"
+				esac
+			}; die_output ;;
+		2) # Syntax err
+			die_message() {
+				case $LANG in
+					en*) printf "$general_die_output %s\\n" "Function $MYFUNCNAME returned $err_code" ;;
+					*) printf "$general_die_output %s\\n" "Function $MYFUNCNAME returned $err_code"
+				esac
+			}; die_output ;;
+		3) # Permission issue
+			die_message() {
+				case $LANG in
+					en*) printf "$general_die_output %s\\n" "Unable to elevate root access from $(id -u)" ;;
+					*) printf "$general_die_output %s\\n" "Unable to elevate root access from $(id -u)"
+				esac
+			}; die_output ;;
+		126) # Not executable
+			die 126 "FIXME(die): Not executable" ;;
+		130) # Killed by user
+			die 130 "Killed by user" ;;
+		wtf|255) # Custom
+			die_message() {
+				case $LANG in
+					en*) printf "$general_die_output %s\\n" "Unexpected result in '$message'" ;;
+					*) printf "$general_die_output %s\\n" "Unexpected result in '$message'"
+				esac
+			}; die_output ;;
+		# Used for development
+    ping) printf "$general_die_output %s\\n" "Killed by ping\n" ; exit 1 ;;
+		# In case error code is not provided
+		fixme)
+			printf 'FIXME: %s\n' "$message"
+			exit 1 ;;
+		*)
+			printf 'ERROR: %s\n' "die without error code has been provided"
+			printf "$general_die_output %s\\n" "$err_code" 1>&2 ; exit 1
+	esac
+
+	unset err_code message
+}

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/edo.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/edo.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'expatch' from Exherbo Linux which is:
+# 	General Public License v2
+
+: "
+Captures error code and output message accordingly
+
+Note that edo might pass if the command used returns error code '0' like some windows programs"
+
+efixme NotTested edo
+
+# Capture arguments into a command variable
+command="$*"
+
+# Set in curly brackets to avoid exit if the command fails
+{
+	# Execute value of 'command' variable and capture error code
+	"$command" || pulsecheck="Dr. McCoy: It's dead Jim"
+	err_code="$?"
+}
+
+# Determine the return based on error code
+case "$err_code" in
+	0) true ;;
+	*) die "$err_code"
+esac
+
+[ -n "$pulsecheck" ] && die 1 "Command 'edo $command' returned error code '0', but command 'edo' captured returned false"
+
+unset err_code command

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/emake.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/emake.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'emake' from Exherbo Linux which is:
+# 	General Public License v2
+
+: '
+Wrapper for command "make"
+
+Options can be parsed using MAKEOPTS in $pckmdir/bashrc (i.e: /etc/paludis/bashrc)
+'
+
+efixme NotTested emake
+
+if command -v make 2>/dev/null; then
+	make "$MAKEOPTS" "$@" || die 1 "Command 'make' failed (fixme, more info needed)"
+elif ! command -v make 2>/dev/null; then
+	die 1 "Command make is not executable on this system"
+else
+	die 255 "emake - checking for command 'make'"
+fi

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/expatch.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/expatch.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'expatch' from Exherbo Linux which is:
+# 	General Public License v2
+
+: "
+Wrapper used to execute 'patch' command which applies patches to source
+
+Usage: expatch [path/to/file.{diff,patch}] [path/to/target]
+
+TODO
+- Expecting to pipe patch in expatch
+- Expecting expatch to patch whole directory or just one file depending on input of path"
+
+die fixme "expatch is not implemented"
+
+efixme NotTested expatch
+
+if command -v patch 2>/dev/null; then
+	patch -r -i "$1" || die "Pa"
+elif command -v patch 2>/dev/null; then
+	die 126 "Command 'patch' is not executable on this system, unable to patch $1"
+else
+	die 255 "checking for patch command"
+fi

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/output/edebug.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/output/edebug.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+Output debug message used for development'
+
+# Used for customization of error messages by the end-user, can be set in $pckmdir/bashrc where pckmdir is for example /etc/paludis
+[ -z "$debug_output" ] && debug_output="DEBUG:"
+
+[ -n "$DEBUG" ] && printf "$debug_output %s\\n" "$1"

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/output/eerror.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/output/eerror.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+Used to handle various error messages
+
+Expected to output an error message for non-fatal errors'
+
+# Used for customization of error messages by the end-user, can be set in $pckmdir/bashrc where pckmdir is for example /etc/paludis
+[ -z "$error_output" ] && error_output="ERROR:"
+
+printf "$error_output %s\\n" "$1"

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/output/efixme.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/output/efixme.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+Output annoying fixme message informing about unimplemented feature
+
+These messages are enabled by default and can be disabled in $pckmdir/bashrc i.e /etc/paludis/bashrc which is not recommended'
+
+# Used for customization of error messages by the end-user, can be set in $pckmdir/bashrc where pckmdir is for example /etc/paludis
+[ -z "$fixme_output" ] && fixme_output="FIXME:"
+
+case "$1" in
+	NotTested)
+		# shellcheck disable=SC2154 # Variable 'ignore_fixme' is expected to be exported by the end-user
+		[ -z "$ignore_fixme" ] && printf "$fixme_output %s\\n" "Command '$1' is not tested" ;;
+	*)
+		# shellcheck disable=SC2154 # Variable 'ignore_fixme' is expected to be exported by the end-user
+		[ -z "$ignore_fixme" ] && printf "$fixme_output %s\\n" "$1"
+esac

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/output/einfo.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/output/einfo.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+Output an info message
+
+Expected to be used to inform end-user about something essential or progress of process'
+
+# Used for customization of error messages by the end-user, can be set in $pckmdir/bashrc where pckmdir is for example /etc/paludis
+[ -z "$info_output" ] && info_output="INFO:"
+
+printf "$info_output %s\\n" "$1"

--- a/paludis/repositories/e/ebuild/exheredrey-0/commands/output/ewarn.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/commands/output/ewarn.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+Output a warn message
+
+Expected to be used to warn an end-user about something important'
+
+# Used for customization of error messages by the end-user, can be set in $pckmdir/bashrc where pckmdir is for example /etc/paludis
+[ -z "$warn_output" ] && warn_output="WARN:"
+
+printf "$warn_output %s\\n" "$1"

--- a/paludis/repositories/e/ebuild/exheredrey-0/fixme_functions.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/fixme_functions.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+Function used to output a message to exit if feature that is not yet implement'
+
+econf() { die fixme "econf which is used to configure packages" ;}
+
+require() { die fixme "Function require is not implemented which is used to source libraries" ;}

--- a/paludis/repositories/e/ebuild/exheredrey-0/phases/03-src_configure.bash
+++ b/paludis/repositories/e/ebuild/exheredrey-0/phases/03-src_configure.bash
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+	# We are using an array to get parameters (blocking POSIX)
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'src_configure' from Exheres-0 which is:
+# 	Copyright (c) 2006, 2007, 2008, 2009 Ciaran McCreesh as GNU General Public License v2
+
+: '
+This phase is used for configuring source prior to compilation (i.e: Generating Makefiles using "configure")
+'
+
+# TODO: Export PFN to point in $PNVR
+
+# Default src_configure phase
+default_src_configure() {
+	# In case source has configure file, run it
+	if [ -f "$WORKDIR/$PFN/configure" ]; then
+		# TODO: DEFAULT_SRC_CONFIGURE_PARAMS is expected to be used for parameters
+		"$WORKDIR/$PFN/configure" "${DEFAULT_SRC_CONFIGURE_PARAMS[@]}" || die 1 "Default configuration of package $PNV failed"
+	elif [ ! -f "$WORKDIR/$PNV/configure" ]; then
+		debug "Configure file for $PFN was not found"
+	else
+		die 255 "src_configure - default"
+	fi
+}
+
+src_configure() {
+	# If src_configure is not exported, run default
+	default configure
+}

--- a/paludis/repositories/e/ebuild/exheredrey-0/phases/04-src_compile.bash
+++ b/paludis/repositories/e/ebuild/exheredrey-0/phases/04-src_compile.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+	# We are using an array to get parameters (blocking POSIX)
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'src_compile' from Exheres-0 which is:
+# 	Copyright (c) 2006, 2007, 2008, 2009 Ciaran McCreesh as GNU General Public License v2
+
+: "
+Phase used to compile package in '$WORKDIR/$PFN'"
+
+default_src_compile() {
+	# Start configuration if we have a makefile
+	if [ -f "$WORKDIR/$PFN/Makefile" ]; then
+		emake -C "$WORKDIR/$PFN" "${DEFAULT_SRC_COMPILE_PARAMS[@]}"
+	elif [ ! -f "$WORKDIR/$PFN/Makefile" ]; then
+		die 1 "Unable to find a Makefile in '$WORKDIR/$PFN', unable to run default compilation"
+	else
+		die 255 "default_src_compile - Checking for makefile"
+	fi
+}
+
+src_compile() {
+	# If src_compile is not exported, run default
+	default compile
+}

--- a/paludis/repositories/e/ebuild/exheredrey-0/phases/06-src_test.bash
+++ b/paludis/repositories/e/ebuild/exheredrey-0/phases/06-src_test.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+	# We are using an array to get parameters (blocking POSIX)
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'src_compile' from Exheres-0 which is:
+# 	Copyright (c) 2006, 2007, 2008, 2009 Ciaran McCreesh as GNU General Public License v2
+
+: "
+Phase used to test package in '$WORKDIR/$PFN'"
+
+default_src_test() {
+	# Start configuration if we have a makefile
+	if [ -f "$WORKDIR/$PFN/Makefile" ]; then
+		if emake -C "$WORKDIR/$PFN" -n check &>/dev/null; then
+			emake -C "$WORKDIR/$PFN" check || die 1 "Tests failed for $PFN"
+		elif emake -C "$WORKDIR/$PFN" -n test &>/dev/null; then
+			emake -C "$WORKDIR/$PFN" test || die 1 "Tests failed for $PFN"
+		else
+			die 255 "src_test - running tests"
+		fi
+	elif [ ! -f "$WORKDIR/$PFN/Makefile" ]; then
+		die 1 "Unable to find a Makefile in '$WORKDIR/$PFN', unable to run tests in for package '$PFN' in '$WORKDIR/$PFN'"
+	else
+		die 255 "default_src_test - Checking for Makefile"
+	fi
+}
+
+src_test() {
+	# If src_test is not exported, run default
+	default test
+}

--- a/paludis/repositories/e/ebuild/exheredrey-0/phases/07-src_install.bash
+++ b/paludis/repositories/e/ebuild/exheredrey-0/phases/07-src_install.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+	# We are using an array to get parameters (blocking POSIX)
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+# Based in part on 'src_compile' from Exheres-0 which is:
+# 	Copyright (c) 2006, 2007, 2008, 2009 Ciaran McCreesh as GNU General Public License v2
+
+: "
+Phase used to install package from '$WORKDIR/$PFN' in '$IMAGEDIR'"
+
+default_src_install() {
+	# Start configuration if we have a makefile
+	if [ -f "$WORKDIR/$PFN/Makefile" ]; then
+		emake -C "$WORKDIR/$PFN" "${DEFAULT_SRC_COMPILE_PARAMS[@]}" DESTDIR="$IMAGEDIR" install || die 1 "Unable to install package $PFN in $IMAGEDIR"
+	elif [ ! -f "$WORKDIR/$PFN/Makefile" ]; then
+		die 1 "Unable to find a Makefile in '$WORKDIR/$PFN', unable to install in $IMAGEDIR"
+	else
+		die 255 "default_src_install - Checking for Makefile"
+	fi
+}
+
+src_install() {
+	# If src_install is not exported, run default
+	default install
+}

--- a/paludis/repositories/e/ebuild/exheredrey-0/unsupported_handler.sh
+++ b/paludis/repositories/e/ebuild/exheredrey-0/unsupported_handler.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Created by Jacob Hrbek <kreyren@rixotstudio.cz> in 2019 under the terms of GNUv3 (https://www.gnu.org/licenses/gpl-3.0.en.html)
+
+: '
+This function generates backend for unsupported features that are either not supported (and waiting to be implemented) or features that are deprecated
+
+This file is expected to be sourced **FIRST** otherwise it may result in a false positive'
+
+# Unsupported functions are generated using this
+for feature in $(for file in $(find ../ -type f | tr '\n' ' '); do grep -oP '\w+\(\)' "$file" | tr '\n' ' '; done); do
+    case "$file" in
+        # Deprecated by 'die'
+        nonfatal|is_nonfatal)
+            printf '%s\n' "$feature { die deprecated \"Function ${feature%%()} is deprecated by 'die'\" ;}" ;;
+        *)
+            printf '%s\n' "$feature { die deprecated \"Function ${feature%%()} is deprecated by 'unknown(fixme)'\" ;}"
+    esac
+done


### PR DESCRIPTION
This is an ongoing effort to make alternative library for package managers that are using bash/shell backend for downstream that is passing shellcheck (not the case on exherbo/gentoo) and is compatible with POSIX and other kernels other then linux.